### PR TITLE
商品一覧表示

### DIFF
--- a/app/assets/stylesheets/_items.scss
+++ b/app/assets/stylesheets/_items.scss
@@ -599,7 +599,3 @@ a {
     }
   }
 }
-
-.index-footer{
-  margin-top: 500px;
-}

--- a/app/assets/stylesheets/_items.scss
+++ b/app/assets/stylesheets/_items.scss
@@ -599,3 +599,7 @@ a {
     }
   }
 }
+
+.index-footer{
+  margin-top: 500px;
+}

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   def index
-    @blands = Item.includes(:images).where.not(bland: nil).where(buyer_id: nil).order("created_at DESC").limit(3)
+    @blands = Item.includes(:images).where.not(bland: "").where(buyer_id: nil).order("created_at DESC").limit(3)
     @newitems = Item.includes(:images).where(buyer_id: nil).order("created_at DESC").limit(3)
   end
 
@@ -34,6 +34,7 @@ class ItemsController < ApplicationController
   private
 
   def item_params
-    params.require(:item).permit(:name,:price,:introduction,:bland,:prefecture_name,:condition_id,:postage_payer,:preparation_day,images_attributes:{url:[]}).merge(seller_id:current_user.id)
+    params.require(:item).permit(:name,:price,:introduction,:bland,:prefecture_name,:condition_id,
+    :postage_payer,:preparation_day,images_attributes:[:url]).merge(seller_id:current_user.id)
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,7 @@
 class ItemsController < ApplicationController
   def index
+    @blands = Item.includes(:images).where.not(bland: nil).where(buyer_id: nil).order("created_at DESC").limit(3)
+    @newitems = Item.includes(:images).where(buyer_id: nil).order("created_at DESC").limit(3)
   end
 
   def new
@@ -32,6 +34,6 @@ class ItemsController < ApplicationController
   private
 
   def item_params
-    params.require(:item).permit(:name,:price,:introduction,:prefecture_name,:condition_id,:postage_payer,:preparation_day,images_attributes:{url:[]}).merge(seller_id:current_user.id)
+    params.require(:item).permit(:name,:price,:introduction,:bland,:prefecture_name,:condition_id,:postage_payer,:preparation_day,images_attributes:{url:[]}).merge(seller_id:current_user.id)
   end
 end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,5 +1,5 @@
 class Image < ApplicationRecord
   belongs_to :item
-  mount_uploaders :url, ImageUploader
+  mount_uploader :url, ImageUploader
   validates :url, presence: true
 end

--- a/app/views/deliveries/new.html.haml
+++ b/app/views/deliveries/new.html.haml
@@ -15,14 +15,14 @@
                 = f.label 'お名前',class: 'form-group__label'
                 %span.form-require
                   必須
-                = f.text_field :content,class: 'form-group__family',placeholder: '例)中村'
-                = f.text_field :content,class: 'form-group__first',placeholder: '例)稜介'
+                = f.text_field :content,class: 'form-group__family',placeholder: '例)橘'
+                = f.text_field :content,class: 'form-group__first',placeholder: '例)秀明'
               .form-group
                 = f.label 'お名前カナ',class: 'form-group__label'
                 %span.form-require
                   必須
-                = f.text_field :content,class: 'form-group__family-kana',placeholder: '例)ナカムラ'
-                = f.text_field :content,class: 'form-group__first-kana',placeholder: '例)リョウスケ'
+                = f.text_field :content,class: 'form-group__family-kana',placeholder: '例)タチバナ'
+                = f.text_field :content,class: 'form-group__first-kana',placeholder: '例)ヒデアキ'
               .form-group
                 = f.label '都道府県',class: 'form-group__label'
                 %span.form-require

--- a/app/views/devise/registrations/new_destination.html.haml
+++ b/app/views/devise/registrations/new_destination.html.haml
@@ -16,14 +16,14 @@
                 = f.label 'お名前',class: 'form-group__label'
                 %span.form-require
                   必須
-                = f.text_field :first_name,class: 'form-group__family',placeholder: '例)中村'
-                = f.text_field :last_name,class: 'form-group__first',placeholder: '例)稜介'
+                = f.text_field :first_name,class: 'form-group__family',placeholder: '例)橘'
+                = f.text_field :last_name,class: 'form-group__first',placeholder: '例)秀明'
               .form-group
                 = f.label 'お名前カナ',class: 'form-group__label'
                 %span.form-require
                   必須
-                = f.text_field :first_name_kana,class: 'form-group__family-kana',placeholder: '例)ナカムラ'
-                = f.text_field :last_name_kana,class: 'form-group__first-kana',placeholder: '例)リョウスケ'
+                = f.text_field :first_name_kana,class: 'form-group__family-kana',placeholder: '例)タチバナ'
+                = f.text_field :last_name_kana,class: 'form-group__first-kana',placeholder: '例)ヒデアキ'
               .form-group
                 = f.label '郵便番号',class: 'form-group__label'
                 %span.form-require

--- a/app/views/items/_headder.html.haml
+++ b/app/views/items/_headder.html.haml
@@ -38,19 +38,3 @@
           %li.headder__nav-listsright-newitem
             = link_to new_user_registration_path,id:'catBtn' do
               新規会員登録
-
-      -# 仮置き
-      -# - if controller.controller_name == 'items'
-      -#   %ul.headder__nav-listsright
-      -#     %li.headder__nav-listsright-loginitem
-      -#       = link_to user_session_path,id:'catBtn' do
-      -#         ログイン
-      -#       %ul.headder__nav-listsright-brandsPulldown
-      -#     %li.headder__nav-listsright-newitem
-      -#       = link_to new_user_registration_path,id:'catBtn' do
-      -#         新規会員登録
-      -# - else
-      -#   %ul.headder__nav-listsright
-      -#     %li.headder__nav-listsright-loginitem
-      -#       = link_to 'http://localhost:3000/users/show',id:'catBtn' do
-      -#         マイページ

--- a/app/views/items/_product.html.haml
+++ b/app/views/items/_product.html.haml
@@ -2,7 +2,7 @@
   = link_to "/" do
     .main__pickupconteiner-productlist-img
       - if product.images.present?
-        = image_tag "#{product.images[0]}"
+        = image_tag "#{product.images[0].url}"
     .main__pickupconteiner-productlist-body
       %h3.main__pickupconteiner-productlist-name
         = product.name

--- a/app/views/items/_product.html.haml
+++ b/app/views/items/_product.html.haml
@@ -1,0 +1,17 @@
+.main__pickupconteiner-productlist
+  = link_to "/" do
+    .main__pickupconteiner-productlist-img
+      - if product.images.present?
+        = image_tag "#{product.images[0]}"
+    .main__pickupconteiner-productlist-body
+      %h3.main__pickupconteiner-productlist-name
+        = product.name
+      .main__pickupconteiner-productlist-details
+        %ul
+          %li
+            = product.price
+          %li
+            %i.fas.fa-star
+            0
+        %p
+          (税込)

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -97,8 +97,9 @@
         = link_to "/" do
           %h3.main__pickupconteiner-producttitle
             新規投稿商品
-      = render partial: 'product', collection: @newitems
-  %section.main__pickupconteiner-last
+      .main__pickupconteiner-productlists
+        = render partial: 'product', collection: @newitems
+  %section.main__pickupconteiner
     %h2.main__pickupconteiner-head
       ピックアップブランド
     .main__pickupconteiner-productbox

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -97,55 +97,7 @@
         = link_to "/" do
           %h3.main__pickupconteiner-producttitle
             新規投稿商品
-      .main__pickupconteiner-productlists
-        .main__pickupconteiner-productlist
-          = link_to "/" do
-            .main__pickupconteiner-productlist-img
-              = image_tag "icon-03.png"
-            .main__pickupconteiner-productlist-body
-              %h3.main__pickupconteiner-productlist-name
-                product3
-              .main__pickupconteiner-productlist-details
-                %ul
-                  %li
-                    30000円
-                  %li
-                    %i.fas.fa-star
-                    0
-                %p
-                  (税込)
-        .main__pickupconteiner-productlist
-          = link_to "/" do
-            .main__pickupconteiner-productlist-img
-              = image_tag "icon-03.png"
-            .main__pickupconteiner-productlist-body
-              %h3.main__pickupconteiner-productlist-name
-                product2
-              .main__pickupconteiner-productlist-details
-                %ul
-                  %li
-                    20000円
-                  %li
-                    %i.fas.fa-star
-                    0
-                %p
-                  (税込)
-        .main__pickupconteiner-productlist
-          = link_to "/" do
-            .main__pickupconteiner-productlist-img
-              = image_tag "icon-03.png"
-            .main__pickupconteiner-productlist-body
-              %h3.main__pickupconteiner-productlist-name
-                product1
-              .main__pickupconteiner-productlist-details
-                %ul
-                  %li
-                    10000円
-                  %li
-                    %i.fas.fa-star
-                    0
-                %p
-                  (税込)
+      = render partial: 'product', collection: @newitems
   %section.main__pickupconteiner-last
     %h2.main__pickupconteiner-head
       ピックアップブランド
@@ -155,52 +107,6 @@
           %h3.main__pickupconteiner-producttitle
             アーカイバ
       .main__pickupconteiner-productlists
-        .main__pickupconteiner-productlist
-          = link_to "/" do
-            .main__pickupconteiner-productlist-img
-              = image_tag "icon-03.png"
-            .main__pickupconteiner-productlist-body
-              %h3.main__pickupconteiner-productlist-name
-                product3
-              .main__pickupconteiner-productlist-details
-                %ul
-                  %li
-                    30000円
-                  %li
-                    %i.fas.fa-star
-                    0
-                %p
-                  (税込)
-        .main__pickupconteiner-productlist
-          = link_to "/" do
-            .main__pickupconteiner-productlist-img
-              = image_tag "icon-03.png"
-            .main__pickupconteiner-productlist-body
-              %h3.main__pickupconteiner-productlist-name
-                product2
-              .main__pickupconteiner-productlist-details
-                %ul
-                  %li
-                    20000円
-                  %li
-                    %i.fas.fa-star
-                    0
-                %p
-                  (税込)
-        .main__pickupconteiner-productlist
-          = link_to "/" do
-            .main__pickupconteiner-productlist-img
-              = image_tag "icon-03.png"
-            .main__pickupconteiner-productlist-body
-              %h3.main__pickupconteiner-productlist-name
-                product1
-              .main__pickupconteiner-productlist-details
-                %ul
-                  %li
-                    10000円
-                  %li
-                    %i.fas.fa-star
-                    0
-                %p
-                  (税込)
-= render "footer"
+        = render partial: 'product', collection: @blands
+.index-footer
+  = render "footer"

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -109,5 +109,4 @@
             アーカイバ
       .main__pickupconteiner-productlists
         = render partial: 'product', collection: @blands
-.index-footer
   = render "footer"

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -17,7 +17,6 @@
               .item-num-0#image-box__container
                 = f.fields_for :images do |i|
                   .input-area
-                    -# = i.file_field :src,style: "display:none", id:"img-file",class: "sell-container__content__upload__items__box__input",required: true
                     = i.file_field :url,name: "item[images_attributes][][url]", style: "display:none", id:"img-file",class: "sell-container__content__upload__items__box__input"
                     %label{for: "img-file"}
                       %i.fas.fa-camera

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -17,7 +17,8 @@
               .item-num-0#image-box__container
                 = f.fields_for :images do |i|
                   .input-area
-                    = i.file_field :url,multiple:true,style: "display:none", id:"img-file",class: "sell-container__content__upload__items__box__input",required: true
+                    -# = i.file_field :src,style: "display:none", id:"img-file",class: "sell-container__content__upload__items__box__input",required: true
+                    = i.file_field :url,name: "item[images_attributes][][url]", style: "display:none", id:"img-file",class: "sell-container__content__upload__items__box__input"
                     %label{for: "img-file"}
                       %i.fas.fa-camera
           .error-messages#error-image

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -27,7 +27,7 @@ Rails.application.configure do
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
+  config.assets.compile = true
 
   # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
 

--- a/db/migrate/20200501104310_create_items.rb
+++ b/db/migrate/20200501104310_create_items.rb
@@ -11,6 +11,7 @@ class CreateItems < ActiveRecord::Migration[5.2]
       # t.references :buyer, foreign_key: true
       t.string :seller_id
       t.string :buyer_id
+      t.string :bland
       t.integer :prefecture_name,null: false
       t.integer :condition_id,null: false
       t.integer :postage_payer,null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,18 +12,6 @@
 
 ActiveRecord::Schema.define(version: 2020_05_03_103421) do
 
-  create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.integer "prefecture"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
-  create_table "conditions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "condition_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
   create_table "destinations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "first_name", null: false
     t.string "last_name", null: false
@@ -57,17 +45,11 @@ ActiveRecord::Schema.define(version: 2020_05_03_103421) do
     t.integer "price", null: false
     t.string "seller_id"
     t.string "buyer_id"
+    t.string "bland"
     t.integer "prefecture_name", null: false
     t.integer "condition_id", null: false
     t.integer "postage_payer", null: false
     t.integer "preparation_day", null: false
-  end
-
-  create_table "postages", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "postage_payer"
-    t.string "preparation_days"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|


### PR DESCRIPTION
#What 
商品一覧表示で出品した商品を閲覧できるように表示した。
以下の機能を実装した。また、カテゴリ機能はカテゴリ実装時に行うする。

1.出品した画像を表示(複数枚表示した場合、最初に出品された画像が表示される)
2.buyer_idに値が入力された場合(売却済になった場合)その商品は表示されないようにする。
3.出品時にブランドを記載した場合、その画像は表示されるようにする。
4.出品された画像は最新のものに更新され3つのみとする。

#Why
商品を出品した際、どの商品が出品されているか確認できるようにするため。
また、売却済の商品は表示されないようにした。

▼商品一覧画像
https://i.gyazo.com/97ab216a7e82d03fd9c335806b3de471.jpg
▼buyer_idを入力した場合
https://i.gyazo.com/fc5a88717bc98713365b67f33aee8685.png
▼商品名のブレイクダンスが消える
https://i.gyazo.com/62603eecce8c1c2b28cdfcda4c074e62.jpg